### PR TITLE
line create-account.yaml removed from teku

### DIFF
--- a/init-install.sh
+++ b/init-install.sh
@@ -132,7 +132,6 @@ setups:
     validator_services:
       - beacon
     compose_path: teku-only/docker-compose.yaml
-    create_account: teku-only/create-account.yaml
     overrides:
 
 # docker settings


### PR DESCRIPTION
the line is removed. Because `teku` doesn't have "create-account.yaml" file